### PR TITLE
Sorting on a POJO property of a persistent object causes an exception #180

### DIFF
--- a/link-rest/src/main/java/com/nhl/link/rest/runtime/cayenne/CayenneProcessorFactory.java
+++ b/link-rest/src/main/java/com/nhl/link/rest/runtime/cayenne/CayenneProcessorFactory.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import javax.ws.rs.core.Response.Status;
 
+import com.nhl.link.rest.runtime.parser.cache.IPathCache;
 import org.apache.cayenne.DataObject;
 import org.apache.cayenne.di.Inject;
 
@@ -62,12 +63,14 @@ public class CayenneProcessorFactory implements IProcessorFactory {
 	private IMetadataService metadataService;
 	private IResourceMetadataService resourceMetadataService;
 	private List<EncoderFilter> filters;
+	private IPathCache pathCache;
 
 	public CayenneProcessorFactory(@Inject IRequestParser requestParser, @Inject IUpdateParser updateParser,
 			@Inject IEncoderService encoderService, @Inject ICayennePersister persister,
 			@Inject IConstraintsHandler constraintsHandler, @Inject IMetadataService metadataService,
 			@Inject IResourceMetadataService resourceMetadataService,
-			@Inject(EncoderService.ENCODER_FILTER_LIST) List<EncoderFilter> filters) {
+			@Inject(EncoderService.ENCODER_FILTER_LIST) List<EncoderFilter> filters,
+			@Inject IPathCache pathCache) {
 		this.requestParser = requestParser;
 		this.encoderService = encoderService;
 		this.persister = persister;
@@ -76,6 +79,7 @@ public class CayenneProcessorFactory implements IProcessorFactory {
 		this.resourceMetadataService = resourceMetadataService;
 		this.updateParser = updateParser;
 		this.filters = filters;
+		this.pathCache = pathCache;
 	}
 
 	@Override
@@ -128,7 +132,7 @@ public class CayenneProcessorFactory implements IProcessorFactory {
 
 		BaseLinearProcessingStage<SelectContext<Object>, Object> stage4 = new CayenneFetchStage<>(null, persister);
 		BaseLinearProcessingStage<SelectContext<Object>, Object> stage3 = new CayenneQueryAssembleStage<>(stage4,
-				persister);
+				persister, pathCache);
 		BaseLinearProcessingStage<SelectContext<Object>, Object> stage2 = new ApplySelectServerParamsStage<>(stage3,
 				encoderService, constraintsHandler, filters);
 		BaseLinearProcessingStage<SelectContext<Object>, Object> stage1 = new ParseSelectRequestStage<>(stage2,

--- a/link-rest/src/main/java/com/nhl/link/rest/runtime/parser/cache/EntityPathCache.java
+++ b/link-rest/src/main/java/com/nhl/link/rest/runtime/parser/cache/EntityPathCache.java
@@ -55,6 +55,11 @@ class EntityPathCache {
 				public ASTPath getPathExp() {
 					return id.getPathExp();
 				}
+
+				@Override
+				public Object getTargetComponent() {
+					return id;
+				}
 			});
 		}
 	}
@@ -86,6 +91,11 @@ class EntityPathCache {
 					public ASTPath getPathExp() {
 						return path;
 					}
+
+					@Override
+					public Object getTargetComponent() {
+						return attribute;
+					}
 				};
 			} else {
 				entry = new PathDescriptor() {
@@ -105,6 +115,11 @@ class EntityPathCache {
 					@Override
 					public ASTPath getPathExp() {
 						return path;
+					}
+
+					@Override
+					public Object getTargetComponent() {
+						return relationship;
 					}
 				};
 			}

--- a/link-rest/src/main/java/com/nhl/link/rest/runtime/parser/cache/PathDescriptor.java
+++ b/link-rest/src/main/java/com/nhl/link/rest/runtime/parser/cache/PathDescriptor.java
@@ -9,4 +9,6 @@ public interface PathDescriptor {
 	Class<?> getType();
 
 	ASTPath getPathExp();
+
+	Object getTargetComponent();
 }

--- a/link-rest/src/test/java/com/nhl/link/rest/it/fixture/cayenne/E15.java
+++ b/link-rest/src/test/java/com/nhl/link/rest/it/fixture/cayenne/E15.java
@@ -1,9 +1,14 @@
 package com.nhl.link.rest.it.fixture.cayenne;
 
+import com.nhl.link.rest.annotation.LrAttribute;
 import com.nhl.link.rest.it.fixture.cayenne.auto._E15;
 
 public class E15 extends _E15 {
 
     private static final long serialVersionUID = 1L; 
 
+    @LrAttribute
+    public String getNonPersistent() {
+        return getName() + "-nonPersistent";
+    }
 }

--- a/link-rest/src/test/java/com/nhl/link/rest/runtime/cayenne/processor/CayenneQueryAssembleStageTest.java
+++ b/link-rest/src/test/java/com/nhl/link/rest/runtime/cayenne/processor/CayenneQueryAssembleStageTest.java
@@ -28,7 +28,7 @@ public class CayenneQueryAssembleStageTest extends TestWithCayenneMapping {
 
 	@Before
 	public void before() {
-		this.fetchStage = new CayenneQueryAssembleStage<>(null, mockCayennePersister);
+		this.fetchStage = new CayenneQueryAssembleStage<>(null, mockCayennePersister, pathCache);
 	}
 
 	@Test

--- a/link-rest/src/test/java/com/nhl/link/rest/unit/TestWithCayenneMapping.java
+++ b/link-rest/src/test/java/com/nhl/link/rest/unit/TestWithCayenneMapping.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.nhl.link.rest.runtime.parser.cache.IPathCache;
+import com.nhl.link.rest.runtime.parser.cache.PathCache;
 import org.apache.cayenne.ObjectContext;
 import org.apache.cayenne.configuration.server.DataSourceFactory;
 import org.apache.cayenne.configuration.server.ServerRuntime;
@@ -65,6 +67,7 @@ public class TestWithCayenneMapping {
 	}
 
 	protected ICayennePersister mockCayennePersister;
+	protected IPathCache pathCache;
 	protected IMetadataService metadataService;
 	protected IResourceMetadataService resourceMetadataService;
 	protected IResourceParser resourceParser;
@@ -80,6 +83,7 @@ public class TestWithCayenneMapping {
 		when(mockCayennePersister.newContext()).thenReturn(runtime.newContext());
 
 		this.metadataService = createMetadataService();
+		this.pathCache = new PathCache(metadataService);
 		this.resourceParser = new ResourceParser(metadataService);
 		this.resourceMetadataService = createResourceMetadataService();
 	}


### PR DESCRIPTION
@andrus , check it out please.

Note that I had to add a new method for IPathDescriptor interface, specifically for the case when sort parameter is a path to related object's attribute (see algorithm in `com.nhl.link.rest.runtime.cayenne.processor.CayenneQueryAssembleStage#findAttribute` and test for this case in `com.nhl.link.rest.it.noadapter.GET_NonPersistentProperties_IT#testGET_Root_SortByRelatedObjectsNonPersistentProperty`)

Feel free to comment and correct me if needed